### PR TITLE
first loaded file has wrong filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "see how long files take to require from the CLI",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/test.js"
   },
   "repository": {
     "type": "git",

--- a/test/bar.js
+++ b/test/bar.js
@@ -1,0 +1,1 @@
+console.log('loading bar from', __filename);

--- a/test/foo.js
+++ b/test/foo.js
@@ -1,0 +1,1 @@
+console.log('loading foo from', __filename);

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,7 @@
+var rt = require('../')();
+rt.start();
+
+require('./foo');
+require('./bar');
+
+rt.end();


### PR DESCRIPTION
I added simple demo / test that shows that the first file loaded has wrong filename reported. The test file simply requires 'foo.js' then 'bar.js', but the report shows bar.js twice. 

```
$ npm test

> require-times@1.0.0 test /Users/gleb/git/require-times
> node test/test.js

loading foo from /Users/gleb/git/require-times/test/foo.js
loading bar from /Users/gleb/git/require-times/test/bar.js
total: 3ms
2ms ./test/bar.js
1ms ./test/bar.js
```
